### PR TITLE
some changes

### DIFF
--- a/papers/source/d1664.bs
+++ b/papers/source/d1664.bs
@@ -5,14 +5,14 @@ Revision: 0
 Audience: LEWG, SG18
 Status: D
 Group: WG21
-URL: 
+URL:
 !Targeting: C++20
 !Latest: <a href="https://thephd.github.io/vendor/future_cxx/papers/d1664.html">https://thephd.github.io/vendor/future_cxx/papers/d1664.html</a>
 Repository: ThePhD/future_cxx
 Editor: JeanHeyd Meneide, phdofthehouse@gmail.com
 Date: 2019-07-06
 Markup Shorthands: markdown yes, biblio yes, markup yes
-Abstract: This paper proposes a new concept to the Standard Library for ranges called Reconstructible Range for the purpose of ensuring a range/view broken down into its two iterators can be "glued" back together using a constructor taking its iterator and sentinel type.
+Abstract: This paper proposes new concepts to the Standard Library for ranges called Reconstructible Ranges for the purpose of ensuring a range/view broken down into its two iterators can be "glued" back together using a constructor taking its iterator and sentinel type.
 </pre>
 
 <pre class=include>
@@ -44,7 +44,7 @@ auto operate_on_and_return_updated_range (Range&& range) {
 	if (std::ranges::empty(range)) {
 		return uRange(std::forward<Range>(range));
 	}
-	/* perform some work with the 
+	/* perform some work with the
 	iterators or similar */
 	auto first = std::ranges::begin(range);
 	auto last = std::ranges::end(range);
@@ -63,7 +63,7 @@ auto operate_on_and_return_updated_range (Range&& range) {
 int main () {
 	std::string_view meow_view = "나는 유리를 먹을 수 있어요. 그래도 아프지 않아요";
 	auto sub_view = operate_on_and_return_updated_range(meow_view);
-	// decltype(sub_view) == 
+	// decltype(sub_view) ==
 	//   std::string_view, ideally
 	//   but instead we get an error =(
 	return 0;
@@ -82,7 +82,7 @@ auto operate_on_and_return_updated_range (Range&& range) {
 	if (std::ranges::empty(range)) {
 		return uRange(std::forward<Range>(range));
 	}
-	// perform some work with the 
+	// perform some work with the
 	// iterators or similar
 	auto first = std::ranges::begin(range);
 	auto last = std::ranges::end(range);
@@ -101,21 +101,21 @@ auto operate_on_and_return_updated_range (Range&& range) {
 int main () {
 	std::string_view meow_view = "나는 유리를 먹을 수 있어요. 그래도 아프지 않아요";
 	auto sub_view = operate_on_and_return_updated_range(meow_view);
-	// decltype(sub_view) == 
+	// decltype(sub_view) ==
 	//   std::ranges::subrange<std::string_view::iterator,std::string_view::iterator>
 	//   which is nowhere close to ideal.
 	return 0;
 }
 ```
 
-This makes it work with any two pair of iterators, but quickly becomes undesirable from an interface point of view. If a user passes in a `std::span<T, Extent>` or a `std::basic_string_view<Char, Traits>` that interface and information is entirely lost to the user of the above function. `std::ranges::sub_range<Iterator, Sentinel, Kind>` does not -- and cannot/should not -- mimic the interface of the view it was created from other than what information comes from its iterators: it is the barebones idea of a pair-of-iterators/iterator-sentinel style of range. This is useful in the generic sense that if a library developer must work with iterators, they can always rely on creation of a `std::ranges::subrange` of the iterator and sentinel.
+This makes it work with any two pair of iterators, but quickly becomes undesirable from an interface point of view. If a user passes in a `std::span<T, Extent>` or a `std::basic_string_view<Char, Traits>` that interface and information is entirely lost to the user of the above function. `std::ranges::subrange<Iterator, Sentinel, Kind>` does not -- and cannot/should not -- mimic the interface of the view it was created from other than what information comes from its iterators: it is the barebones idea of a pair-of-iterators/iterator-sentinel style of range. This is useful in the generic sense that if a library developer must work with iterators, they can always rely on creation of a `std::ranges::subrange` of the iterator and sentinel.
 
-Unfortunately, this decreases usability for end users. Users who have, for example a `std::string_view` would prefer to have the same type after such an operation is performed. There is little reason why the original type needs to be discarded if it supports being put back together from its iterators. It also discards any range-specific storage optimizations and layout considerations, leaving us with the most bland kind of range similar to the "pair of iterators" model. Compilation time goes up as well: users must spawn a fresh `std::ranges::sub_range<I, S, K>` for every different set of iterator/sentinel/kind triplet.
+Unfortunately, this decreases usability for end users. Users who have, for example a `std::string_view` would prefer to have the same type after such an operation is performed. There is little reason why the original type needs to be discarded if it supports being put back together from its iterators. It also discards any range-specific storage optimizations and layout considerations, leaving us with the most bland kind of range similar to the "pair of iterators" model. Compilation time goes up as well: users must spawn a fresh `std::ranges::subrange<I, S, K>` for every different set of iterator/sentinel/kind triplet.
 
 There is also a problem where there are a wide variety of ranges that could conceivably meet this criterion, but do not. Attempts to change this for Eric Niebler's range-v3 library were also denied after the initial inquiry, due to focusing only on a singular type. Specifically:
 
 > I don't add things because I can't find a reason not to. I add things selectively based on need and on design integrity.
-> 
+>
 > There is no generic code that can use the functionality you are proposing because that expression is not part of any concept. — [[range-v3-sentinel-issue|Eric Niebler, May 15th, 2019]]
 
 Still, the author of this paper was not the only one to see utility in such operations. [[p1739r0]] does much the same that this paper does, without the introduction of a concept to formalize the behavior it presents. In particular, it selects views which can realistically have their return types changed to match the input range and operations being performed (or a similarly powerful alternative) by asking whether they are constructible from a subrange of the iterators with the expressions acted upon.
@@ -130,22 +130,28 @@ In short, this paper formalizes the work done in P1739 by giving it an expositio
 
 # Design # {#design}
 
-The concept is simple and is given in 2 exposition-only types added to the standard:
+The design is simple and is given in 2 exposition-only concepts added to the standard:
 
 ```
 template <typename R>
-concept pair-reconstructible-range = 
-    forwarding-range<std::remove_reference_t<R>> && 
-    std::Constructible<std::remove_reference_t<R>, iterator_t<R>, sentinel_t<R>>;
+concept pair-reconstructible-range =
+    Range<R> &&
+    forwarding-range<std::remove_reference_t<R>> &&
+    std::Constructible<R, iterator_t<R>, sentinel_t<R>>;
 
 template <typename R>
-concept range-reconstructible-range = 
-    forwarding-range<std::remove_reference_t<R>> && 
-    std::Constructible<std::remove_reference_t<R>, std::ranges::subrange<iterator_t<R>, sentinel_t<R>>>;
+concept range-reconstructible-range =
+    Range<R> &&
+    forwarding-range<std::remove_reference_t<R>> &&
+    std::Constructible<R, std::ranges::subrange<iterator_t<R>, sentinel_t<R>>>;
 ```
 
-It is the formalization that a range can be constructed from its begin iterator and end iterator/sentinel. It also provides an exposition concept for allowing a range to be constructed from a `subrange` of its iterator/sentinel pair. This allows a developer to propagate the input type's properties after modifying its iterators for some underlying work, algorithm or other effect. This concept is also the basis of the idea behind [[p1739r0]].
+It is the formalization that a range can be constructed from its begin iterator and end iterator/sentinel. It also provides an exposition-only concept for allowing a range to be constructed from a `subrange` of its iterator/sentinel pair. This allows a developer to propagate the input type's properties after modifying its iterators for some underlying work, algorithm or other effect. This concept is also the basis of the idea behind [[p1739r0]].
 
+Both concepts require that the type with any references removed model the exposition-only concept `forwarding-range`.
+This ensures that the validity of the iterators is in fact independent of the lifetime of the range they originate from
+and that a "reconstructed" range does not depend on the original.
+We remove reference before performing this check, because all reference types that model `Range` also model `forwarding-range` and the intent of the proposed changes is narrower: (re)construction is assumed to be in constant time (this typically implies that `R` also models `View`, but it is sufficient to check `forwarding-range<std::remove_reference_t<R>>`). Note that this explicitly excludes types like `std::vector<int> const &` from being reconstructible.
 
 
 ## Should this apply to all Ranges? ## {#design-all}
@@ -158,21 +164,28 @@ For example `std::ranges::single_view` contains a [exposition *semiregular-box* 
 
 ## Applicability ## {#design-applicable}
 
-There are many ranges to which this is applicable, but only a handful in the standard library need or satisfy this. If [[p1391r2]] and [[p1394r2]] are accepted, then the two most important view types -- `std::span<T, Extent>` and `std::basic_string_view<Char, Traits>` -- will have this concept applied to it. `std::ranges::subrange<Iterator, Sentinel, Kind>` already fits this as well. By making it a concept in the standard, we can dependably and reliably assert that these properties continue to hold for the ranges which it is desirable. Some ranges and range customization point objects to which this would be helpfully applicable to in the current standard and proposals space are:
+There are many ranges to which this is applicable, but only a handful in the standard library need or satisfy this. If [[p1391r2]] and [[p1394r2]] are accepted, then the two most important view types -- `std::span<T, Extent>` and `std::basic_string_view<Char, Traits>` -- will model both concepts. `std::ranges::subrange<Iterator, Sentinel, Kind>` already fits this as well. By formalizing concepts in the standard, we can dependably and reliably assert that these properties continue to hold for these ranges. The ranges to which this would be helpfully applicable to in the current standard and proposals space are:
+
+- `std::ranges::subrange` (already reconstructible)
+- `std::span` (currently under consideration, [[p1394r2]]);
+- `std::basic_string_view` (currently under consideration, [[p1391r2]]);
+- `std::ranges::empty_view` (proposed here);
+- and, `std::ranges::iota_view` (proposed here).
+
+The following range adaptor closure objects will make use of the concepts in determing the type of the returned range:
 
 - `view::drop` (currently under consideration, [[p1035r6]] and [[p1739r0]], re-proposed here);
-- `view::take` (currently under consideration, [[p1739r0]], re-proposed here);
-- `std::span` as a reconstructible range (currently under consideration, [[p1394r2]]);
-- `std::basic_string_view` as a reconstructible range (currently under consideration, [[p1391r2]]);
-- `std::ranges::empty_view` as a reconstructible range (proposed here);
-- and, `std::ranges::iota_view` as a reconstructible range (proposed here).
+- `view::take` (currently under consideration, [[p1739r0]], re-proposed here).
 
-
-There are also upcoming ranges from [[range-v3]] and elsewhere that could have this concept applied to it as well:
+There are also upcoming ranges from [[range-v3]] and elsewhere that could model this concept:
 
 - [[p1255r4]]'s `std::ranges::ref_maybe_view`;
 - [[p0009r9]]'s `std::mdspan`;
 - and, soon to be proposed by this author for the purposes of output range algorithms, [[range-v3]]'s `ranges::unbounded_view`.
+
+And there are further range adaptor closure objects that could make use of this concept:
+
+- `view::slice`, `view::take_exactly`, `view::drop_exactly` and `view::take_last` from [[range-v3]]
 
 Note that these changes will greatly aid other algorithm writers who want to preserve the same input ranges. In the future, it may be beneficial to provide more than just an exposition-only concept to check, but rather a function in the standard in `std::ranges` of the form `template <typename Range> reconstruct(Iterator, Sentinel);`, whose goal is to check if it is possible to reconstruct the `Range` or otherwise return a `std::ranges::subrange`.
 
@@ -183,7 +196,7 @@ This paper does not propose this at this time because concepts -- and the things
 
 By giving these ranges `Iterator, Sentinel`, **or** `std::ranges::subrange<Iterator, Sentinel>` constructors, we can enable a greater degree of interface fidelity without having to resort to `std::ranges::subrange` for all generic algorithms. There should be a preference for `Type(Iterator, Sentinel)` constructors, because one-argument constructors have extremely overloaded meanings in many containers and some views and may result in having to fight with other constructor calls in a complicated overload set. It also produces less compiler boilerplate to achieve the same result of reconstructing the range when one does not have to go through `std::ranges::subrange<I, S, K>`. However, it is important to attempt to move away from the iterator, sentinel model being deployed all the time: `std::ranges::subrange` offers a single type that can accurately represent the intent and can be fairly easy to constrain overload sets on (most of the time).
 
-This paper includes a concept that covers both reconstructible methods, to support both old and new views and ranges.
+This paper includes two concepts that cover both reconstructible methods.
 
 
 
@@ -216,7 +229,8 @@ The intent of this wording is to provide greater generic coding guarantees and o
 - add expression checks to `view::take` to reconstruct the range, similar to [[p1739r0]];
 - add expression checks to `view::drop` to reconstruct the range, similar to [[p1739r0]] and from [[p1035r6]];
 - add constructors for reconstructing the range to `view::empty_view`;
-- and, add constructors for reconstructing the range to `view::iota_view`.
+- add constructors for reconstructing the range to `view::iota_view`;
+- and, make `view::iota_view` model *forwarding-range* by adding `friend` overloads of `begin()` and `end()`.
 
 For ease of reading, the necessary portions of other proposal's wording is duplicated here, with the changes necessary for the application of reconstructible range concepts. Such sections are clearly marked.
 
@@ -243,7 +257,22 @@ Append to §17.3.1 General [[support.limits.general](http://eel.is/c++draft/supp
 Insert into §24.4.4 Ranges [[range.range](http://eel.is/c++draft/range.req#range.range)]'s after clause 7, one additional clause:
 
 <blockquote>
-<ins><sup>8</sup> The <i>pair-reconstructible-range</i> and <i>range-reconstructible-range</i> concepts denote ranges whose iterator and sentinel pair can be used to construct an object of the type from which they originated. That is, given an expression `E` such that `decltype((E))` is `T`, then `T(ranges::begin(E), ranges::end(E))` and `T(ranges::subrange(ranges::begin(E), ranges::end(E)))` are well-formed, respectively.</ins>
+<ins><sup>8</sup> The exposition-only <i>pair-reconstructible-range</i> and <i>range-reconstructible-range</i> concepts denote ranges whose iterator and sentinel pair can be used to efficiently construct an object of the type from which they originated.
+
+```
+template <typename R>
+concept pair-reconstructible-range =
+    Range<R> &&
+    forwarding-range<std::remove_reference_t<R>> &&
+    std::Constructible<R, iterator_t<R>, sentinel_t<R>>;
+
+template <typename R>
+concept range-reconstructible-range =
+    Range<R> &&
+    forwarding-range<std::remove_reference_t<R>> &&
+    std::Constructible<R, std::ranges::subrange<iterator_t<R>, sentinel_t<R>>>;
+```
+</ins>
 </blockquote>
 
 Add to §24.6.1.2 Class template `empty_view` [[range.empty.view](http://eel.is/c++draft/range.empty.view)], a constructor in the synopsis and a new clause for constructor definitions:
@@ -322,7 +351,15 @@ namespace std::ranges {
     constexpr iterator begin() const;
     constexpr sentinel end() const;
     constexpr iterator end() const requires Same<W, Bound>;
+```
+<ins>
+```
+    constexpr friend iterator begin(iota_view v);
+    constexpr friend auto end(iota_view v);
 
+```
+</ins>
+```
     constexpr auto size() const
       requires (Same<W, Bound> && Advanceable<W>) ||
                (Integral<W> && Integral<Bound>) ||
@@ -348,7 +385,25 @@ constexpr iota_view(iterator first, sentinel last);
 </ins>
 </blockquote>
 
+Add to §24.6.3 Class template `iota_view` [[range.iota.view](http://eel.is/c++draft/range.iota.view)], after clause 11 (old) / 12 (new):
 
+<blockquote>
+<ins>
+```
+constexpr friend iterator begin(iota_view v);
+```
+<p><sup>13</sup> Effects: Equivalent to: `return v.begin();`</p>
+</ins>
+</blockquote>
+
+<blockquote>
+<ins>
+```
+constexpr friend auto end(iota_view v);
+```
+<p><sup>14</sup> Effects: Equivalent to: `return v.end();`</p>
+</ins>
+</blockquote>
 
 ## Proposed Library + P1739 wording ## {#wording-p1739}
 
@@ -358,8 +413,8 @@ Modify §24.7.6.4 `view::take` [[range.take.adaptor](http://eel.is/c++draft/rang
 <p><sup>1</sup> The name `view::take` denotes a range adaptor object. <del>For some subexpressions `E` and `F`, the expression `view::take(E, F)` is expression-equivalent to `take_­view{E, F}`.</del></p>
 <p><ins><sup>2</sup> Let `E` and `F` be expressions, and let T be `remove_cvref_t<decltype((E))>`. Then the expression `view::take(E, F)` is expression-equivalent to:</ins></p>
 <dl>
-	<dd><ins>— `T{ranges::begin(E), ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F)}` if `T` satisfies <i>pair-reconstructible-range</i>;</ins></dd>
-	<dd><ins>— `T{ranges::subrange{ranges::begin(E), ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F)}}` if `T` satisfies <i>range-reconstructible-range</i>;</ins></dd>
+	<dd><ins>— `T{ranges::begin(E), ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F)}` if `T` models ranges::RandomAccessRange, ranges::SizedRange and <i>pair-reconstructible-range</i>;</ins></dd>
+	<dd><ins>— `T{ranges::subrange{ranges::begin(E), ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F)}}` if `T` models ranges::RandomAccessRange, ranges::SizedRange and <i>range-reconstructible-range</i>;</ins></dd>
 	<dd><ins>— `ranges::take_­view{E, F}` if that is well-formed;</ins></dd>
 	<dd><ins>— otherwise, `view::take(E, F)` is ill-formed.</ins></dd>
 </dl>
@@ -370,12 +425,12 @@ Modify §24.7.6.4 `view::take` [[range.take.adaptor](http://eel.is/c++draft/rang
 Modify [[p1035r6]]'s §23.7.8 `view::drop` as follows:
 
 <blockquote>
-<p><sup>1</sup> The name `view::drop` denotes a range adaptor object. 
+<p><sup>1</sup> The name `view::drop` denotes a range adaptor object.
 <del>For some subexpressions E and F, the expression view::drop(E, F) is expression-equivalent to drop_­view{E, F}.</del></p>
 <p><ins><sup>2</sup> Let `E` and `F` be expressions, and let `T` be `remove_cvref_t<decltype((E))>`. Then, the expression `view::drop(E, F)` is expression-equivalent to:</ins></p>
 <dl>
-	<dd><ins>— `T{ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F), ranges::end(E)}` if `T` satisfies <i>pair-reconstructible-range</i>;</ins></dd>
-	<dd><ins>— `T{ranges::subrange{ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F), ranges::end(E)}}` if `T` satisfies <i>range-reconstructible-range</i>;</ins></dd>
+	<dd><ins>— `T{ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F), ranges::end(E)}` if `T` models ranges::RandomAccessRange, ranges::SizedRange and <i>pair-reconstructible-range</i>;</ins></dd>
+	<dd><ins>— `T{ranges::subrange{ranges::begin(E) + min<iter_­difference_­t<iterator_t<decltype((E))>>>(ranges::size(E), F), ranges::end(E)}}` if `T` models ranges::RandomAccessRange, ranges::SizedRange and <i>range-reconstructible-range</i>;</ins></dd>
 	<dd><ins>— `ranges::drop_­view{E, F}` if the expression is well-formed;</ins></dd>
 	<dd><ins>— otherwise, `view::drop(E, F)` is ill-formed.</ins></dd>
 </dl>


### PR DESCRIPTION
This contains some minor and some slightly bigger changes. Most minor changes are fixes where you spoke of "the concept" (originally referring to a single concept) that I changed to referring to multiple concepts.

I have also added some more description on why I think `forwarding-range` is the central requirement for this concept, although I am unsure if maybe you and me actually were talking about different things. You don't want `std::vector` to model `reconstructible-range`, right? We are targeting `O(1)` reconstruction and we are expecting the reconstructed object to be independent of the original, right? Then we need `forwarding-range` IMHO!

I will add some more descriptions in between the lines.

Regarding the process: I don't know how these things go usually. Since this subsumes my paper, I would be fine with "retracting" mine and maybe becoming co-author of this one? At least I have already convinced Titus to schedule P1739 directly in LEWG (without going through Incubator) and doing it as early as possible so that it can go to LWG before the week is over (in case LEWG accepts it). Maybe we can squeeze this into the same slot.

I guess this also depends on whether we can get Casey behind it. He suggested mild support for P1739 in #ranges.