### PR TITLE
Fix markdown in {} init paper

### DIFF
--- a/papers/source/C - Consistent, Warningless, and Intuitive Initialization with {}.bs
+++ b/papers/source/C - Consistent, Warningless, and Intuitive Initialization with {}.bs
@@ -125,7 +125,7 @@ int main () {
 
 ## Consistent "static storage duration initialization" ## {#design-consistent}
 
-*Almost* every single compiler which was surveyed, that implements this extension, agrees that "`= { }`" should be the same as "`= { 0 }`", just without the confusing `0` value within the braces (with one notable exception, below). It performs what the C standard calls _static initialization_ / _static storage duration initialization_. Therefore, the wording (and, with minor parsing updates, implementation) burden is minimal since we are not introducing a new class of initialization to the language, just extending an already-in-use syntax.
+*Almost* every single compiler which was surveyed, that implements this extension, agrees that "`= { }`" should be the same as "`= { 0 }`", just without the confusing `0` value within the braces (with one notable exception, below). It performs what the C standard calls *static initialization* / *static storage duration initialization*. Therefore, the wording (and, with minor parsing updates, implementation) burden is minimal since we are not introducing a new class of initialization to the language, just extending an already-in-use syntax.
 
 We note that there are cases where this may differ. These are listed in the sub-sections below, though we note that these departures from what `= { 0 }` does are mostly beneficial and ways to guarantee even greater stability than the C Standard currently offers us.
 


### PR DESCRIPTION
I assume these terms are supposed to be in italics, but don't think bikeshed supports using underscores for that. Replace with asterisks.