### PR TITLE
Fix typo

### DIFF
--- a/papers/source/C - Variable-Length Array (VLA) Allocation Control.bs
+++ b/papers/source/C - Variable-Length Array (VLA) Allocation Control.bs
@@ -344,8 +344,6 @@ int main () {
 
 ## With Transparent Aliases ## {#interaction-with.transparent.aliases}
 
-This feature can be used in multiple different ways with different 
-
 With [Transparent Aliases](https://thephd.dev/_vendor/future_cxx/papers/C%20-%20Transparent%20Aliases.html), a future feature that is not yet in Standard C, the VLA allocation can provide a locally-specific allocation function that is not visible to other scopes. For example:
 
 ```cpp


### PR DESCRIPTION
There is a small stray sentence fragment in the paper at the start of section 4.2. It doesn't seem to be related to the surrounding text, so I suggest removing it.
