### PR TITLE
Fix Minor Typo In Example Source Code

### DIFF
--- a/papers/source/C - Expression Evaluation and Access in _Generic.bs
+++ b/papers/source/C - Expression Evaluation and Access in _Generic.bs
@@ -142,8 +142,8 @@ int use_int_ptr(int* pi);
 int use_dbl_ptr(double* pd);
 
 #define USE_THING(THING) _Generic(THING, \
-	int pi: use_int_ptr(pi), \
-	double pd: use_dbl_ptr(pd): \
+	int pi: use_int_ptr(&pi), \
+	double pd: use_dbl_ptr(&pd): \
 	default: 0 \
 )
 


### PR DESCRIPTION
The example was incorrectly copied/pasted into Godbolt.